### PR TITLE
Remove compromised polyfill.io script from MathJax include

### DIFF
--- a/_includes/scripts/mathjax.html
+++ b/_includes/scripts/mathjax.html
@@ -8,5 +8,4 @@
     };
   </script>
   <script defer type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@{{ site.mathjax.version }}/es5/tex-mml-chtml.js"></script>
-  <script defer src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   {%- endif %}


### PR DESCRIPTION
## What

Removes the `polyfill.io` script tag from `_includes/scripts/mathjax.html`.

```diff
-  <script defer src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
```

## Why

`polyfill.io` was the domain behind the **June 2024 supply-chain attack**: after the domain was sold to Funnull (Feb 2024), it began injecting malicious JavaScript that redirected visitors to scam/betting/adult sites. The operator was **OFAC-sanctioned in May 2025**, and the domain is now broadly blocklisted (uBlock Origin, DNS filters, endpoint AV).

This line shipped with the old al-folio template and loaded on **every page** of the site (`enable_math: true` in `_config.yml`, included via `_layouts/default.html`). As of 2026 the original malware host `cdn.polyfill.io` is dead (NXDOMAIN) and the apex returns HTTP 401/403 — so today the practical effect is a **broken/blocked third-party request plus ongoing supply-chain risk**, not an active payload from this exact URL. Either way it should go.

## Why delete instead of swapping to a mirror

The `es6` polyfill was only ever needed for **IE11** (EOL June 2022). MathJax 3's `es5/tex-mml-chtml.js` build (already loaded from jsdelivr) runs natively on every modern browser, so deleting the line is **zero functional loss** — and MathJax's own docs now recommend against using `polyfill.io`. Upstream al-folio swapped to the Cloudflare cdnjs mirror, which is a fine alternative, but deleting removes a whole third-party origin and an entire class of future supply-chain risk.

## Testing

- `grep -rni "polyfill\.io"` → no remaining references
- `grep -rni "googie|anaiytics|gtags.js"` → typosquat loader not present (confirms source was never modified; the malware was only ever served client-side by the CDN)
- MathJax loader (`mathjax@{{ site.mathjax.version }}/es5/tex-mml-chtml.js`) is untouched — math rendering is unaffected on modern browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
